### PR TITLE
fix: update Flutter version, remove .PluginRegistry.Registrar

### DIFF
--- a/android/src/main/java/com/cindyu/all_sensors/AllSensorsPlugin.java
+++ b/android/src/main/java/com/cindyu/all_sensors/AllSensorsPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import static android.content.Context.POWER_SERVICE;
 
@@ -32,16 +31,6 @@ public class AllSensorsPlugin implements FlutterPlugin {
   private EventChannel userAccelChannel;
   private EventChannel gyroscopeChannel;
   private EventChannel proximityChannel;
-
-
-  /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
-
-    AllSensorsPlugin plugin = new AllSensorsPlugin();
-    plugin.setupEventChannels(registrar.context(), registrar.messenger());
-
-  }
-
   private void setupEventChannels(Context context, BinaryMessenger messenger) {
 
     accelerometerChannel = new EventChannel(messenger, ACCELEROMETER_CHANNEL_NAME);


### PR DESCRIPTION
PluginRegistry.Registrar being deprecated in Flutter, which occurs when migrating from older Flutter versions to the new Android embedding (v2)
